### PR TITLE
fix: install missing D-Bus service file for kglobalacceld

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kglobalacceld (6.2.1-1deepin4) unstable; urgency=medium
+
+  * fix: install missing D-Bus service file for kglobalacceld
+
+ -- justforlxz <justforlxz@gmail.com>  Wed, 06 May 2026 12:28:46 +0800
+
 kglobalacceld (6.2.1-1deepin3) unstable; urgency=medium
 
   * update Replaces version

--- a/debian/kglobalacceld.install
+++ b/debian/kglobalacceld.install
@@ -1,3 +1,4 @@
 etc/xdg/autostart/kglobalacceld.desktop
 usr/lib/*/libexec/kglobalacceld
 usr/lib/systemd/user/plasma-kglobalaccel.service
+usr/share/dbus-1/services/org.kde.kglobalaccel.service

--- a/debian/patches/0001-install-dbus-service-file.patch
+++ b/debian/patches/0001-install-dbus-service-file.patch
@@ -1,0 +1,26 @@
+Description: Install missing D-Bus service file for kglobalacceld
+ Add org.kde.kglobalaccel.service.in file and install it to
+ KDE_INSTALL_DBUSSERVICEDIR for D-Bus auto-activation.
+Author: justforlxz <justforlxz@gmail.com>
+Origin: vendor
+Forwarded: not-needed
+Last-Update: 2026-05-06
+
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -85,3 +85,8 @@ ecm_install_configured_files(
+     INPUT kglobalacceld.desktop.in
+     DESTINATION ${KDE_INSTALL_AUTOSTARTDIR} @ONLY
+ )
++
++ecm_install_configured_files(
++   INPUT org.kde.kglobalaccel.service.in
++   DESTINATION ${KDE_INSTALL_DBUSSERVICEDIR}
++)
+--- /dev/null
++++ b/src/org.kde.kglobalaccel.service.in
+@@ -0,0 +1,4 @@
++[D-BUS Service]
++Name=org.kde.kglobalaccel
++Exec=@KDE_INSTALL_FULL_LIBEXECDIR@/kglobalacceld
++SystemdService=plasma-kglobalaccel.service

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+0001-install-dbus-service-file.patch


### PR DESCRIPTION
Add org.kde.kglobalaccel.service.in file and install it to KDE_INSTALL_DBUSSERVICEDIR for D-Bus auto-activation.

添加D-Bus服务激活文件，支持kglobalacceld的D-Bus自动激活。

Log: 添加D-Bus服务文件安装
PMS: BUG-351589
Influence: 安装后D-Bus可以在需要时自动启动kglobalacceld守护进程